### PR TITLE
Enable memory Horizontal Pod Autoscaling by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ ctfd:
     # -- Autoscaling target CPU utilization percentage
     targetCPUUtilizationPercentage: 80
     # -- Autoscaling target memory utilization percentage
-    # targetMemoryUtilizationPercentage: 80
+    targetMemoryUtilizationPercentage: 80
   resources:
     # -- CTFd pod CPU limit
     limits:


### PR DESCRIPTION
This pull request enables both memory/cpu Horizontal Pod Autoscaling (HPA) by default. The `targetMemoryUtilizationPercentage` setting is uncommented and set to 80, allowing for autoscaling based on memory utilization.