### PR TITLE
Replace mariadb with galera

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,10 +13,10 @@ dependencies:
     version: 20.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
-  - name: mariadb
-    version: 19.0.5
+  - name: mariadb-galera
+    version: 14.0.12
     repository: https://charts.bitnami.com/bitnami
-    condition: mariadb.enabled
+    condition: mariadb-galera.enabled
   - name: seaweedfs
     version: 4.0.0
     repository: https://seaweedfs.github.io/seaweedfs/helm

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -17,10 +17,10 @@
 ░░░░▒▓█████████▓▒░░░░░░░░░░██▓░░░░░░░░░▒██░░░░░░░░░░░░░░▓███████░░█▒░░░░░░░░░░░░
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
 ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
-                                                                     CTFd v{{ .Values.ctfd.image.tag | default .Chart.AppVersion }}
+                                                                     version: {{ .Values.ctfd.image.tag | default .Chart.AppVersion }}
 
 
-{{ if or .Values.mariadb.enabled .Values.redis.enabled -}}
+{{ if or (index .Values "mariadb-galera" "enabled") (.Values.redis.enabled) -}}
 ** Please be patient while MariaDB or Redis are being deployed **
 {{ end }}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -62,13 +62,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-   Generate CTFd DATABASE_URL (internal bitnami mariadb or external self managed mariadb)
+   Generate CTFd DATABASE_URL (internal bitnami mariadb-galera or external self managed mariadb-galera)
 */}}
 {{- define "ctfd.DATABASE_URL" -}}
-{{- if .Values.mariadb.enabled -}}
-mysql+pymysql://{{ .Values.mariadb.auth.username | default "ctfd" }}:{{ .Values.mariadb.auth.password | default "ctfd" }}@{{ .Release.Name }}-mariadb{{ if eq .Values.mariadb.architecture "replication" }}-primary{{ end }}/{{ .Values.mariadb.auth.database | default "ctfd" }}
+{{- if index .Values "mariadb-galera" "enabled" -}}
+mysql+pymysql://{{ index .Values "mariadb-galera" "db" "user" | default "ctfd" }}:{{ index .Values "mariadb-galera" "db" "password" | default "ctfd" }}@{{ .Release.Name }}-mariadb-galera/{{ index .Values "mariadb-galera" "db" "name"| default "ctfd" }}
 {{- else -}}
-mysql+pymysql://{{ .Values.mariadb.external.username }}:{{ .Values.mariadb.external.password }}@{{ .Values.mariadb.external.host }}/{{ .Values.mariadb.external.database }}
+mysql+pymysql://{{ index .Values "mariadb-galera" "external" "username" }}:{{ index .Values "mariadb-galera" "external" "password" }}@{{ index .Values "mariadb-galera" "external" "host" }}/{{ index .Values "mariadb-galera" "external" "database" }}
 {{- end -}}
 {{- end -}}
 

--- a/values.yaml
+++ b/values.yaml
@@ -66,7 +66,7 @@ ctfd:
 
   ingress:
     # -- Enables ingress
-    enabled: false
+    enabled: true
     # -- Ingress class
     className: ""
     # -- Ingress annotations
@@ -75,7 +75,7 @@ ctfd:
       # kubernetes.io/tls-acme: "true"
     # @ignored
     hosts:
-      - host: ctfd.local
+      - host: ctfd.example.com
         paths:
           - path: /
             pathType: ImplementationSpecific
@@ -182,16 +182,27 @@ ctfd:
     name: ""
 
 # Override the mariadb subchart values
-mariadb:
-  # -- Deploys bitnami's mariadb (set to false if you want to use an external database)
+mariadb-galera:
+  # -- Deploys bitnami's mariadb-galera (set to false if you want to use an external database)
   enabled: true
-  # -- MariaDB Architecture (`standalone`, `replication`)
-  architecture: standalone
-  auth:
-    rootPassword: ctfd
-    username: ctfd
+  db:
+    user: ctfd
     password: ctfd
-    database: ctfd
+    name: ctfd
+  galera:
+    mariabackup:
+      password: ctfd
+  rootUser:
+    password: ctfd
+  resourcesPreset: large
+  persistence:
+    enabled: true
+    size: 2Gi
+  # -- MariaDB primary entrypoint extra flags
+  # @default -- Check `values.yaml`. Used by official CTFd `docker-compose.yml`
+  extraFlags: "--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --wait_timeout=28800 --log-warnings=0"
+  metrics:
+    enabled: true  # prometheus metrics exporter
   # -- External database connection details. Takes effect if `mariadb.enabled` is set to false
   # @default -- ignored
   external:
@@ -200,29 +211,6 @@ mariadb:
     username: ""
     password: ""
     database: ""
-  volumePermissions:
-    enabled: true  # set to false if you want to manage the permissions yourself
-  primary:
-    # -- MariaDB primary entrypoint extra flags
-    # @default -- Check `values.yaml`. Used by official CTFd `docker-compose.yml`
-    extraFlags: "--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --wait_timeout=28800 --log-warnings=0"
-    # -- Check Bintami's documentation
-    resourcesPreset: small
-    persistence:
-      enabled: true
-      size: 2Gi
-  secondary:
-    # -- MariaDB primary entrypoint extra flags
-    # @default -- Check `values.yaml`. Used by official CTFd `docker-compose.yml`
-    extraFlags: "--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --wait_timeout=28800 --log-warnings=0"
-    # -- Check Bintami's documentation
-    resourcesPreset: small
-    replicaCount: 1
-    persistence:
-      enabled: true
-      size: 2Gi
-  metrics:
-    enabled: true  # prometheus metrics exporter
 
 # Override the redis subchart values (I am considering the switch from redis to redis-ha)
 redis:


### PR DESCRIPTION

Replaced mariadb with mariadb-galera, a multi-primary database cluster.


https://github.com/bitnami/charts/tree/main/bitnami/mariadb-galera

![image](https://github.com/user-attachments/assets/6019f993-94b4-48c9-9ec8-ba361826aaf6)
