### PR TITLE
Replace SeaweedFS with MinIO

### DIFF
--- a/.github/workflows/helm-chart-release.yaml
+++ b/.github/workflows/helm-chart-release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: add helm repos
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add seaweedfs https://seaweedfs.github.io/seaweedfs/helm
+          helm repo add seaweedfs helm repo add minio https://charts.min.io
           helm repo update
 
       - name: Run chart-releaser

--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -20,7 +20,7 @@ permissions:
   contents: read
 
 jobs:
-  lint-test:
+  lint-serverside-dryrun:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://ctfd.io/static/img/ctfd.svg
 type: application
 
 # Dev note: trigger a helm chart release by bumping the version
-version: 0.2.0
+version: 0.3.0
 
 # Redis, MySQL/MariaDB and Seaweedfs
 dependencies:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,6 +5,7 @@ icon: https://ctfd.io/static/img/ctfd.svg
 
 type: application
 
+# Dev note: trigger a helm chart release by bumping the version
 version: 0.2.0
 
 # Redis, MySQL/MariaDB and Seaweedfs

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -17,7 +17,8 @@ dependencies:
     version: 14.0.12
     repository: https://charts.bitnami.com/bitnami
     condition: mariadb-galera.enabled
-  - name: seaweedfs
-    version: 4.0.0
-    repository: https://seaweedfs.github.io/seaweedfs/helm
-    condition: seaweedfs.enabled
+  - name: minio
+    alias: minio
+    version: 5.4.0
+    repository: https://charts.min.io/
+    condition: minio.enabled

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -17,7 +17,7 @@ helm install ctfd ctfd/ctfd -f values.yaml
 
 ## Install from source
 
-Build helm dependencies (MariaDB/Redis/SeaweedFS) before installing the chart.
+Build helm dependencies (MariaDB/Redis/Minio) before installing the chart.
 
 ```bash
 helm dependency update
@@ -38,12 +38,12 @@ helm uninstall release-name --namespace ctfd
 
 - CTFd `SECRET_KEY` is automatically generated during installation/upgrade. You can find it in the secret `release-name-ctfd-secret-key`. This secret is injected as environment variable in all CTFd pods.
 - Redis in this chart uses single master with multiple workers.
-- This chart deploys SeaweedFS S3 as an uploadprovider. You can use AWS S3 or any other external S3 compatible storage as an upload provider. Just set `seaweedfs.enabled` to `false` and configure the external S3 provider in `ctfd.uploadprovider.s3`.
+- This chart deploys Minio S3 bucket as an uploadprovider. You can use AWS S3 or any other external S3 compatible storage as an upload provider. Just set `minio.enabled` to `false` and configure the external S3 provider in `ctfd.uploadprovider.s3`.
 - This chart intentionally refrains from supporting `filesystem` uploadprovider. This needs `ReadWriteMany` PVCs which are expensive in cloud providers and not recommended for production use. S3 is fast and cheap.
 
 ## Values examples
 
-### Deploy Bitnami MariaDB/Redis and SeaweedFS S3
+### Deploy Bitnami MariaDB/Redis and Minio
 ```yaml
 ctfd:
   image:
@@ -52,17 +52,17 @@ ctfd:
     enabled: true
     minReplicas: 2
     maxReplicas: 10
-mariadb:
+mariadb-galera:
   enabled: true
-  architecture: standalone
-  primary:
+  persistence:
+    enabled: true
     size: 2Gi
 redis:
   enabled: true
-seaweedfs:
+minio:
   enabled: true
-  s3:
-    enabled: true
+  persistence:
+    size: 10Gi
 ```
 
 ### Configure your own external DB/Redis/S3
@@ -80,7 +80,7 @@ ctfd:
       endpoint_url: ""
       secret_access_key: ""
       access_key_id: ""
-mariadb:
+mariadb-galera:
   enabled: false
   external:
     port: 3306
@@ -95,7 +95,7 @@ redis:
     host: ""
     username: ""
     password: ""
-seaweedfs:
+minio:
   enabled: false
 ```
 
@@ -107,32 +107,25 @@ ctfd:
   replicas: 2
   autoscaling:
     enabled: false
-  resources:
-    limits:
-      cpu: "2"
-      memory: 2Gi
-    requests:
-      cpu: "1"
-      memory: 1Gi
 ```
 
 ## Features
 
 - [x] HA and horizontal autoscaling with CPU and memory metrics
 - [x] Configurable CPU/memory requests and limits
-- [x] Deploys bitnami Redis, bitnami MariaDB and SeaweedFS S3 as Helm dependencies
+- [x] Deploys bitnami Redis, bitnami MariaDB-Galera and ~~SeaweedFS S3~~ (REPLACED WITH MINIO) as Helm dependencies 
 - [X] Option to use AWS S3 or any other external S3 compatible storage as an upload provider
 - [x] Option to use external Redis and MariaDB (e.g., AWS RDS, ElastiCache)
 - [x] Customizable CTFd configuration
-- [x] Adjustable configurations for Redis and MariaDB
-- [x] Integration with external storage as upload provider (AWS S3 or SeaweedFS or any S3 compatible storage)
+- [x] Adjustable configurations for Redis and MariaDB-Galera
+- [x] Integration with external storage as upload provider (AWS S3 or Minio or any S3 compatible storage)
 - [x] Liveness and Readiness checks
 - [x] Affinity/Toleration/nodeSelector rules
 - [x] Automatically rolls out config updates to CTFd pods (Using checksum annotation)
 - [ ] Deploys self-hosted mail server for CTFd email notifications as a helm dependency
 - [ ] Automated backups (CTFd export. This could be done with batch/v1 CronJob)
 - [ ] Deploys postgres db as a helm dependency (ctfd.io doesn't actively support it so this is a low priority)
-- [ ] Support for custom CTFd themes/plugin (using initContainers?)
+- [ ] Support for custom CTFd themes/plugin (using initContainers? this is WIP)
 
 ## To Do
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -21,7 +21,7 @@
 
 
 {{ if or (index .Values "mariadb-galera" "enabled") (.Values.redis.enabled) -}}
-** Please be patient while MariaDB or Redis are being deployed **
+** Please be patient while MariaDB and/or Redis are being deployed **
 {{ end }}
 
 Get the list of pods by executing:

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -84,3 +84,13 @@ redis://{{ .Release.Name }}-redis-master:6379
 redis://{{ .Values.redis.external.username }}:{{ .Values.redis.external.password }}@{{ .Values.redis.external.host }}:{{ .Values.redis.external.port }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+   Generate CTFd MINIO_URL
+*/}}
+{{- define "ctfd.MINIO_URL" -}}
+{{- if .Values.minio.enabled -}}
+http://{{ .Release.Name }}-minio:9000
+{{- else -}}
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -90,7 +90,7 @@ redis://{{ .Values.redis.external.username }}:{{ .Values.redis.external.password
 */}}
 {{- define "ctfd.MINIO_URL" -}}
 {{- if .Values.minio.enabled -}}
-http://{{ .Release.Name }}-minio:9000
+http://{{ (index .Values.minio.ingress.hosts 0) }}
 {{- else -}}
 {{- end -}}
 {{- end -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -19,7 +19,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
       {{- with .Values.ctfd.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -50,8 +49,20 @@ spec:
               name: {{ include "ctfd.fullname" . }}
           - secretRef:
               name: {{ include "ctfd.fullname" . }}-secret-key
-          - configMapRef:
-              name: {{ include "ctfd.fullname" . }}
+          env: 
+            {{- .Values.ctfd.env | toYaml | nindent 12 }}
+            {{- if .Values.minio.enabled }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-minio
+                  key: rootUser
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ .Release.Name }}-minio
+                  key: rootPassword
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.ctfd.service.port }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,8 +47,6 @@ spec:
           envFrom:
           - secretRef:
               name: {{ include "ctfd.fullname" . }}
-          - secretRef:
-              name: {{ include "ctfd.fullname" . }}-secret-key
           env: 
             {{- .Values.ctfd.env | toYaml | nindent 12 }}
             {{- if .Values.minio.enabled }}

--- a/templates/extra-manifests.yaml
+++ b/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{ range .Values.extraObjects }}
+---
+{{ if typeIs "string" . }}
+    {{- tpl . $ }}
+{{- else }}
+    {{- tpl (toYaml .) $ }}
+{{- end }}
+{{ end }}

--- a/templates/secret-key.yaml
+++ b/templates/secret-key.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ include "ctfd.fullname" . }}-secret-key
-type: Opaque
-data:
-  SECRET_KEY: {{ randAlphaNum 64 | b64enc }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -6,6 +6,7 @@ type: Opaque
 data:
   DATABASE_URL: {{ include "ctfd.DATABASE_URL" . | b64enc }}
   REDIS_URL: {{ include "ctfd.REDIS_URL" . | b64enc }}
+  SECRET_KEY: {{ randAlphaNum 64 | b64enc }}
 {{- if not .Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ .Values.ctfd.uploadprovider.s3.access_key_id | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.ctfd.uploadprovider.s3.secret_access_key | b64enc }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -6,15 +6,13 @@ type: Opaque
 data:
   DATABASE_URL: {{ include "ctfd.DATABASE_URL" . | b64enc }}
   REDIS_URL: {{ include "ctfd.REDIS_URL" . | b64enc }}
-{{- if not .Values.seaweedfs.enabled }}
+{{- if not .Values.minio.enabled }}
   AWS_ACCESS_KEY_ID: {{ .Values.ctfd.uploadprovider.s3.access_key_id | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.ctfd.uploadprovider.s3.secret_access_key | b64enc }}
   AWS_S3_BUCKET: {{ .Values.ctfd.uploadprovider.s3.bucket | b64enc }}
   AWS_S3_ENDPOINT_URL: {{ .Values.ctfd.uploadprovider.s3.endpoint_url | b64enc }}
 {{- end }}
-{{- if .Values.seaweedfs.enabled }}
-  AWS_ACCESS_KEY_ID: {{ "seaweedfs" | b64enc }}
-  AWS_SECRET_ACCESS_KEY: {{ "seaweedfs" | b64enc }}
-  AWS_S3_BUCKET: {{ "ctfd-bucket" | b64enc }}
-  AWS_S3_ENDPOINT_URL: {{ "http://seaweedfs-s3:8333" | b64enc }}
+{{- if .Values.minio.enabled }}
+  AWS_S3_BUCKET: {{ (index .Values.minio.buckets 0).name | b64enc }}
+  AWS_S3_ENDPOINT_URL: {{ include "ctfd.MINIO_URL" . | b64enc }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -70,7 +70,9 @@ ctfd:
     # -- Ingress class
     className: ""
     # -- Ingress annotations
-    annotations: {}
+    annotations:
+      # -- Max body size for uploads (Check CTFd github repository's nginx configurations)
+      nginx.ingress.kubernetes.io/proxy-body-size: "2G"
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     # @ignored
@@ -185,24 +187,34 @@ ctfd:
 mariadb-galera:
   # -- Deploys bitnami's mariadb-galera (set to false if you want to use an external database)
   enabled: true
+  # -- Number of primary nodes replicas
+  replicaCount: 3
   db:
+    # -- ctfd database user
     user: ctfd
+    # -- ctfd database password
     password: ctfd
+    # -- ctfd database name
     name: ctfd
+  # -- backup user (This is required by the subchart to do helm upgrades)
   galera:
     mariabackup:
+      # -- backup user (This is required by the subchart to do helm upgrades)
       password: ctfd
   rootUser:
+    # -- root user
     password: ctfd
+  # -- request and limits preset (check bitnami's mariadb-galera chart for details)
   resourcesPreset: large
   persistence:
     enabled: true
+    # -- PVC size
     size: 2Gi
   # -- MariaDB primary entrypoint extra flags
   # @default -- Check `values.yaml`. Used by official CTFd `docker-compose.yml`
   extraFlags: "--character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --wait_timeout=28800 --log-warnings=0"
   metrics:
-    enabled: true  # prometheus metrics exporter
+    enabled: false  # prometheus metrics exporter
   # -- External database connection details. Takes effect if `mariadb.enabled` is set to false
   # @default -- ignored
   external:

--- a/values.yaml
+++ b/values.yaml
@@ -260,21 +260,31 @@ redis:
 
 # Override the minio subchart values
 minio:
+  # -- Deploys Minio (set to false if you want to use an external S3 bucket)
   enabled: true
   buckets:
+      # -- Default bucket to be used by CTFd `download` policy means this bucket is readonly for anonymous access (competitors)
     - name: ctfd-bucket
-      policy: readonly
+      policy: download
       purge: false
+  # -- Ingress configurations of minio (Used by both CTFd and competitiors)
   ingress:
     enabled: true
     hosts:
-      - minio.example.local
+      - minio.example.com
+    annotations:
+      # -- Max Body size `0 -> unlimited` (if you are using another ingress controller then look for the equivalent annotation) 
+      nginx.ingress.kubernetes.io/proxy-body-size: "0"
+  # -- Minio number of replicas
   replicas: 3
-  drivesPerNode: 4
+  # -- Minio number of drives per replica/node
+  drivesPerNode: 1
   resources:
     requests:
-      memory: 4Gi
+      memory: 2Gi
+  # -- Minio PVC size (change according to your needs)
   persistence:
     size: 10Gi
 
+# -- Made for deploying custom manifests with this helm chart
 extraObjects: []

--- a/values.yaml
+++ b/values.yaml
@@ -56,7 +56,7 @@ ctfd:
   uploadprovider:
     s3:
       # -- AWS S3 bucket name
-      bucket: ""  # external bucket (you should disable SeaweedFS. See below)
+      bucket: ""  # external bucket (you should disable Minio. See below)
       # -- AWS S3 bucket region
       endpoint_url: ""
       # -- AWS S3 bucket access key
@@ -121,7 +121,7 @@ ctfd:
     periodSeconds: 10
     timeoutSeconds: 5
     successThreshold: 1
-    failureThreshold: 5
+    failureThreshold: 10
 
   # -- CTFd readiness probe
   # @default -- Check `values.yaml`
@@ -133,7 +133,7 @@ ctfd:
     periodSeconds: 10
     timeoutSeconds: 5
     successThreshold: 1
-    failureThreshold: 5
+    failureThreshold: 10
 
   initContainers: []
 
@@ -246,39 +246,23 @@ redis:
   metrics:
     enabled: true  # prometheus metrics exporter
 
-# Override the seaweedfs subchart values
-seaweedfs:
-  # -- Deploys seaweedfs (set to false if you want to use an bucket)
-  enabled: true  # set to false if you want to use an external bucket
-  master:
-    # -- seaweedfs-master replicas
-    replicas: 1
-    data:
-      # -- seaweedfs data storage type
-      type: "persistentVolumeClaim"
-      # -- seaweedfs storage size
-      size: 5Gi
+# Override the minio subchart values
+minio:
+  enabled: true
+  buckets:
+    - name: ctfd-bucket
+      policy: readonly
+      purge: false
+  ingress:
+    enabled: true
+    hosts:
+      - minio.example.local
+  replicas: 3
+  drivesPerNode: 4
+  resources:
+    requests:
+      memory: 4Gi
+  persistence:
+    size: 10Gi
 
-  volume:
-    # -- seaweedfs-volume replicas
-    replicas: 1
-  filer:
-    # -- seaweedfs-filer replicas
-    replicas: 1
-    # -- seaweedfs-filer enable PVC for data persistence
-    enablePVC: true
-    # -- seaweedfs-filer PVC storage size
-    storage: 5Gi
-    data:
-      # -- seaweedfs-filer data storage type
-      type: "persistentVolumeClaim"
-      # -- seaweedfs-filer storage size
-      size: 5Gi
-    s3:
-      # -- seaweedfs-s3 enable. This enables S3 API (Should be left to `true`)
-      enabled: true
-      # -- seaweedfs-s3 enable authentication (no need since seaweed is private to the cluster)
-      enableAuth: false
-      # -- seaweedfs-s3 create bucket upon deploying
-      createBuckets:
-        - name: ctfd-bucket
+extraObjects: []


### PR DESCRIPTION
I faced alot of  issues in SeaweedFS that has to do bucket permissions (anonymous read-only access for users). So I decided to replace it with Minio. Users can still use their own external S3 buckets regardless. This PR updates `README.md` as well

This should resolve https://github.com/ScribblerCoder/CTFd-Helm/issues/18