### PR TITLE
Allow external secrets for S3 and MariaDB

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -73,6 +73,13 @@ spec:
                   name: {{ .Release.Name }}-minio
                   key: rootPassword
             {{- end }}
+            {{- if (index .Values "mariadb-galera").external.secretRef.name }}
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ (index .Values "mariadb-galera").external.secretRef.name }}
+                  key: {{ (index .Values "mariadb-galera").external.secretRef.databaseUrlKey }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.ctfd.service.port }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,6 +49,18 @@ spec:
               name: {{ include "ctfd.fullname" . }}
           env: 
             {{- .Values.ctfd.env | toYaml | nindent 12 }}
+            {{- if and (not .Values.minio.enabled) .Values.ctfd.uploadprovider.s3.secretRef.name }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ctfd.uploadprovider.s3.secretRef.name }}
+                  key: {{ .Values.ctfd.uploadprovider.s3.secretRef.idKey }}
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef: 
+                  name: {{ .Values.ctfd.uploadprovider.s3.secretRef.name }}
+                  key: {{ .Values.ctfd.uploadprovider.s3.secretRef.secretKey }}
+            {{- end }}
             {{- if .Values.minio.enabled }}
             - name: AWS_ACCESS_KEY_ID
               valueFrom:

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -4,7 +4,9 @@ metadata:
   name: {{ include "ctfd.fullname" . }}
 type: Opaque
 data:
+{{- if not (index .Values "mariadb-galera").external.secretRef.name }}
   DATABASE_URL: {{ include "ctfd.DATABASE_URL" . | b64enc }}
+{{- end }}
   REDIS_URL: {{ include "ctfd.REDIS_URL" . | b64enc }}
   SECRET_KEY: {{ randAlphaNum 64 | b64enc }}
 {{- if not .Values.minio.enabled }}

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -8,8 +8,10 @@ data:
   REDIS_URL: {{ include "ctfd.REDIS_URL" . | b64enc }}
   SECRET_KEY: {{ randAlphaNum 64 | b64enc }}
 {{- if not .Values.minio.enabled }}
+  {{- if not .Values.ctfd.uploadprovider.s3.secretRef.name }}
   AWS_ACCESS_KEY_ID: {{ .Values.ctfd.uploadprovider.s3.access_key_id | b64enc }}
   AWS_SECRET_ACCESS_KEY: {{ .Values.ctfd.uploadprovider.s3.secret_access_key | b64enc }}
+  {{- end }}
   AWS_S3_BUCKET: {{ .Values.ctfd.uploadprovider.s3.bucket | b64enc }}
   AWS_S3_ENDPOINT_URL: {{ .Values.ctfd.uploadprovider.s3.endpoint_url | b64enc }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -224,6 +224,9 @@ mariadb-galera:
   external:
     port: 3306
     host: external-mariadb-host
+    secretRef:
+      name: null
+      databaseUrlKey: DATABASE_URL
     username: ""
     password: ""
     database: ""

--- a/values.yaml
+++ b/values.yaml
@@ -55,6 +55,10 @@ ctfd:
 
   uploadprovider:
     s3:
+      secretRef:
+        name: null
+        secretKey: AWS_SECRET_ACCESS_KEY
+        idKey: AWS_ACCESS_KEY_ID
       # -- AWS S3 bucket name
       bucket: ""  # external bucket (you should disable Minio. See below)
       # -- AWS S3 bucket region


### PR DESCRIPTION
This modification allows use of external secrets for S3 and MariaDB instead of hard coding credentials into values.yaml

```yaml

minio:
  enabled: false

ctfd:
  uploadprovider:
    s3:
      secretRef:
        name: s3-credentials
      bucket: bucketName
      endpoint_url: s3Endpoint
 
mariadb-galera:
  enabled: false
  external:
    secretRef:
      name: mariadb-credentials
```

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: s3-credentials
data:
  AWS_ACCESS_KEY_ID: <id>
  AWS_SECRET_ACCESS_KEY:  <key>
```

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: mariadb-credentials
data:
  DATABASE_URL: <database url>
```



